### PR TITLE
fix: attempting to fix the req /session 500 error

### DIFF
--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -598,15 +598,17 @@ router.post('/session', async (req, res) => {
     let userInfo: { name: string; description: string; avatar: string; userId: string; root: boolean; roles: UserRole[]; config: UserConfig; advanced: AdvancedConfig }
     if (userId != null) {
       const user = await getUserById(userId)
-      userInfo = {
-        name: user.name,
-        description: user.description,
-        avatar: user.avatar,
-        userId: user._id.toString(),
-        root: user.roles.includes(UserRole.Admin),
-        roles: user.roles,
-        config: user.config,
-        advanced: user.advanced,
+      if (user != null) {
+        userInfo = {
+          name: user.name,
+          description: user.description,
+          avatar: user.avatar,
+          userId: user._id.toString(),
+          root: user.roles.includes(UserRole.Admin),
+          roles: user.roles,
+          config: user.config,
+          advanced: user.advanced,
+        }
       }
 
       const keys = (await getCacheApiKeys()).filter(d => hasAnyRole(d.userRoles, user.roles))

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -598,17 +598,32 @@ router.post('/session', async (req, res) => {
     let userInfo: { name: string; description: string; avatar: string; userId: string; root: boolean; roles: UserRole[]; config: UserConfig; advanced: AdvancedConfig }
     if (userId != null) {
       const user = await getUserById(userId)
-      if (user != null) {
-        userInfo = {
-          name: user.name,
-          description: user.description,
-          avatar: user.avatar,
-          userId: user._id.toString(),
-          root: user.roles.includes(UserRole.Admin),
-          roles: user.roles,
-          config: user.config,
-          advanced: user.advanced,
-        }
+      if (user === null) {
+        globalThis.console.error(`session userId ${userId} but query user is null.`)
+        res.send({
+          status: 'Success',
+          message: '',
+          data: {
+            auth: hasAuth,
+            allowRegister,
+            model: config.apiModel,
+            title: config.siteConfig.siteTitle,
+            chatModels,
+            allChatModels: chatModelOptions,
+          },
+        })
+        return
+      }
+
+      userInfo = {
+        name: user.name,
+        description: user.description,
+        avatar: user.avatar,
+        userId: user._id.toString(),
+        root: user.roles.includes(UserRole.Admin),
+        roles: user.roles,
+        config: user.config,
+        advanced: user.advanced,
       }
 
       const keys = (await getCacheApiKeys()).filter(d => hasAnyRole(d.userRoles, user.roles))

--- a/service/src/middleware/auth.ts
+++ b/service/src/middleware/auth.ts
@@ -37,7 +37,7 @@ async function getUserId(req: Request): Promise<string | undefined> {
     return info.userId
   }
   catch (error) {
-
+    globalThis.console.error('getUserId err. ', error.message)
   }
   return null
 }

--- a/service/src/middleware/auth.ts
+++ b/service/src/middleware/auth.ts
@@ -30,14 +30,15 @@ async function auth(req, res, next) {
 }
 
 async function getUserId(req: Request): Promise<string | undefined> {
+  let token: string
   try {
-    const token = req.header('Authorization').replace('Bearer ', '')
+    token = req.header('Authorization').replace('Bearer ', '')
     const config = await getCacheConfig()
     const info = jwt.verify(token, config.siteConfig.loginSalt.trim()) as AuthJwtPayload
     return info.userId
   }
   catch (error) {
-    globalThis.console.error('getUserId err. ', error.message)
+    globalThis.console.error(`auth middleware getUserId err from token ${token} `, error.message)
   }
   return null
 }


### PR DESCRIPTION
ref: #418 
看起来只有可能是在
https://github.com/chatgpt-web-dev/chatgpt-web/blob/39e94f258f6333842ff298f37b5108a75344f314/service/src/index.ts#L600
这里 user 为 null 了才能返回这么个错误导致页面跳转 500

再往上看又只能是 在mongo中没有查询到这个userId的情况下才会执行到这么个路径。
但是为什么数据库会查不到就想不明白了。

ping @Kerwin1202
做个判空处理先避免页面500要求重新登录如何?