### PR TITLE
feat: add global config option enable user usage count limit function

### DIFF
--- a/service/src/storage/model.ts
+++ b/service/src/storage/model.ts
@@ -197,6 +197,7 @@ export class SiteConfig {
     public registerMails?: string,
     public siteDomain?: string,
     public chatModels?: string,
+    public usageCountLimit?: boolean,
   ) { }
 }
 

--- a/src/components/common/Setting/General.vue
+++ b/src/components/common/Setting/General.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { computed, onMounted, ref } from 'vue'
-import { NButton, NDivider, NInput, NInputNumber, NPopconfirm, NSelect, useMessage } from 'naive-ui'
+import { NButton, NDivider, NInput, NPopconfirm, NSelect, useMessage } from 'naive-ui'
 import { UserConfig } from '@/components/common/Setting/model'
 import type { Language, Theme } from '@/store/modules/app/helper'
 import { SvgIcon } from '@/components/common'
@@ -172,13 +172,13 @@ function handleImportButtonClick(): void {
           <NInput v-model:value="description" placeholder="" />
         </div>
       </div>
-      <div class="flex items-center space-x-4">
+      <div v-if="authStore.session?.usageCountLimit && userStore.userInfo.limit" class="flex items-center space-x-4">
         <span class="flex-shrink-0 w-[100px]">{{ $t('setting.useAmount') }}</span>
         <div class="flex-1">
-          <NInputNumber v-model:value="useAmount" placeholder="" readonly />
+          <div v-text="useAmount" />
         </div>
       </div>
-      <div class="flex items-center space-x-4">
+      <div v-if="authStore.session?.usageCountLimit && userStore.userInfo.limit" class="flex items-center space-x-4">
         <span class="flex-shrink-0 w-[100px]">{{ $t('setting.redeemCardNo') }}</span>
         <div class="flex-1">
           <NInput v-model:value="redeemCardNo" placeholder="" />

--- a/src/components/common/Setting/Site.vue
+++ b/src/components/common/Setting/Site.vue
@@ -130,6 +130,16 @@ onMounted(() => {
           </div>
         </div>
         <div class="flex items-center space-x-4">
+          <span class="flex-shrink-0 w-[100px]">{{ $t('setting.usageCountLimit') }}</span>
+          <div class="flex-1">
+            <NSwitch
+              :round="false"
+              :value="config && config.usageCountLimit"
+              @update:value="(val) => { if (config) config.usageCountLimit = val }"
+            />
+          </div>
+        </div>
+        <div class="flex items-center space-x-4">
           <span class="flex-shrink-0 w-[100px]" />
           <NButton :loading="saving" type="primary" @click="updateSiteInfo(config)">
             {{ $t('common.save') }}

--- a/src/components/common/Setting/User.vue
+++ b/src/components/common/Setting/User.vue
@@ -85,36 +85,26 @@ const createColumns = (): DataTableColumns => {
       minWidth: 80,
       maxWidth: 200,
     },
-    // 新增额度信息
-    {
-      title: 'Amts',
-      key: 'useAmount',
-      resizable: true,
-      width: 80,
-      minWidth: 30,
-      maxWidth: 100,
-    },
     // switch off amt limit
     {
-      title: 'limit switch',
+      title: 'Limit Enabled',
       key: 'limit_switch',
       resizable: true,
       width: 100,
       minWidth: 30,
       maxWidth: 100,
       render(row: any) {
-          return h(NSwitch, {
-          defaultValue: row.limit_switch,
-          round: false,
-          disabled: true,
-        })
+        return h('div', row.limit_switch ? 'True' : 'False')
       },
     },
     // 新增额度信息
     {
-      title: 'Amts',
+      title: 'Amounts',
       key: 'useAmount',
+      resizable: true,
       width: 80,
+      minWidth: 30,
+      maxWidth: 100,
     },
     {
       title: 'Action',

--- a/src/components/common/Setting/model.ts
+++ b/src/components/common/Setting/model.ts
@@ -29,6 +29,7 @@ export class SiteConfig {
   registerMails?: string
   siteDomain?: string
   chatModels?: string
+  usageCountLimit?: boolean
 }
 
 export class MailConfig {

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -81,6 +81,7 @@ export default {
   },
   setting: {
     limit_switch: 'Open Usage Limitation',
+    usageCountLimit: 'Enable Usage Count Limit',
     redeemCardNo: 'Redeem CardNo',
     useAmount: 'No. of questions',
     setting: 'Setting',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -81,6 +81,7 @@ export default {
   },
   setting: {
     limit_switch: '打开次数限制',
+    usageCountLimit: '使用次数限制',
     redeemCardNo: '兑换码卡号',
     useAmount: '可提问次数',
     setting: '设置',

--- a/src/store/modules/auth/index.ts
+++ b/src/store/modules/auth/index.ts
@@ -21,6 +21,7 @@ interface SessionResponse {
     key: string
     value: string
   }[]
+  usageCountLimit: boolean
   userInfo: { name: string; description: string; avatar: string; userId: string; root: boolean; config: UserConfig }
 }
 

--- a/src/store/modules/user/helper.ts
+++ b/src/store/modules/user/helper.ts
@@ -12,6 +12,7 @@ export interface UserInfo {
   config: UserConfig
   roles: UserRole[]
   advanced: SettingsState
+  limit?: boolean
   useAmount?: number // chat usage amount
   redeemCardNo?: string // add giftcard info
 }

--- a/src/store/modules/user/index.ts
+++ b/src/store/modules/user/index.ts
@@ -22,7 +22,9 @@ export const useUserStore = defineStore('user-store', {
     },
     // 对应页面加载时的读取，为空送10个
     async readUserAmt() {
-      this.userInfo.useAmount = (await (fetchUserAmt())).data ?? 10
+      const data = (await fetchUserAmt()).data
+      this.userInfo.limit = data?.limit
+      this.userInfo.useAmount = data?.amount ?? 10
     },
 
     async resetSetting() {


### PR DESCRIPTION
https://github.com/chatgpt-web-dev/chatgpt-web/pull/430#issuecomment-1974962186

> 管理员 也显示这个兑换，不是很合理？目前看昨天的合并有一个针对每个用户的开关，没有全局的开关。
