### PR TITLE
修复当用户上传非png图片给vision模型时报错

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -33,6 +33,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.3",
     "express-rate-limit": "^6.7.0",
+    "file-type": "^19.0.0",
     "gpt-token": "^0.0.5",
     "https-proxy-agent": "^5.0.1",
     "isomorphic-fetch": "^3.0.0",

--- a/service/pnpm-lock.yaml
+++ b/service/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   express-rate-limit:
     specifier: ^6.7.0
     version: 6.7.0(express@4.18.3)
+  file-type:
+    specifier: ^19.0.0
+    version: 19.0.0
   gpt-token:
     specifier: ^0.0.5
     version: 0.0.5
@@ -585,6 +588,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@tokenizer/token@0.3.0:
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+    dev: false
 
   /@types/body-parser@1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
@@ -2029,6 +2036,15 @@ packages:
       flat-cache: 3.0.4
     dev: true
 
+  /file-type@19.0.0:
+    resolution: {integrity: sha512-s7cxa7/leUWLiXO78DVVfBVse+milos9FitauDLG1pI7lNaJ2+5lzPnr2N24ym+84HVwJL6hVuGfgVE+ALvU8Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      readable-web-to-node-stream: 3.0.2
+      strtok3: 7.0.0
+      token-types: 5.0.1
+    dev: false
+
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
@@ -2301,6 +2317,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+    dev: false
+
+  /ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: false
 
   /ignore@5.2.4:
@@ -2977,6 +2997,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /peek-readable@5.0.0:
+    resolution: {integrity: sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==}
+    engines: {node: '>=14.16'}
+    dev: false
+
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -3099,6 +3124,22 @@ packages:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
+    dev: false
+
+  /readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+    dev: false
+
+  /readable-web-to-node-stream@3.0.2:
+    resolution: {integrity: sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==}
+    engines: {node: '>=8'}
+    dependencies:
+      readable-stream: 3.6.2
     dev: false
 
   /regexp-tree@0.1.27:
@@ -3365,6 +3406,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /strtok3@7.0.0:
+    resolution: {integrity: sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      peek-readable: 5.0.0
+    dev: false
+
   /stubborn-fs@1.2.4:
     resolution: {integrity: sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w==}
     dev: false
@@ -3401,6 +3450,14 @@ packages:
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+    dev: false
+
+  /token-types@5.0.1:
+    resolution: {integrity: sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
     dev: false
 
   /tr46@0.0.3:

--- a/service/src/utils/image.ts
+++ b/service/src/utils/image.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import * as fileType from 'file-type'
 
 fs.mkdir('uploads').then(() => {
   globalThis.console.log('Directory uploads created')
@@ -12,7 +13,10 @@ fs.mkdir('uploads').then(() => {
 
 export async function convertImageUrl(uploadFileKey: string): Promise<string> {
   const imageData = await fs.readFile(`uploads/${uploadFileKey}`)
+  //判断文件格式
+  const imageType = await fileType.fileTypeFromBuffer(imageData)
+  const mimeType = imageType.mime;
   // 将图片数据转换为 Base64 编码的字符串
   const base64Image = imageData.toString('base64')
-  return `data:image/png;base64,${base64Image}`
+  return `data:${mimeType};base64,${base64Image}`
 }

--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -720,7 +720,7 @@ onUnmounted(() => {
                 :headers="uploadHeaders"
                 :show-file-list="false"
                 response-type="json"
-                accept="image/*"
+                accept="image/png, image/jpeg, image/webp, image/gif"
                 @finish="handleFinish"
               >
                 <span class="text-xl text-[#4f555e] dark:text-white">


### PR DESCRIPTION
原代码我看写死了图片类型是png，当用户上传非png图片时由于传给模型的图片类型还是png，会直接报错。我对后端进行了修改，自动判断图片类型传给模型。同时修改了前端，限定了用户上传的图片格式只能是png jpeg webp gif四种（目前openai支持也仅支持这四种图片）